### PR TITLE
gitignore outputs dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Outputs/


### PR DESCRIPTION
adds Outputs directory to the git ignore to prevent accidental secret publishing